### PR TITLE
Fix NoMethodError when overrides column is NULL

### DIFF
--- a/app/models/railspress/focal_point.rb
+++ b/app/models/railspress/focal_point.rb
@@ -30,7 +30,7 @@ module Railspress
 
     # Get override for specific context
     def override_for(context)
-      overrides[context.to_s]&.with_indifferent_access
+      overrides&.dig(context.to_s)&.with_indifferent_access
     end
 
     # Check if context has custom override (not using focal point)

--- a/spec/models/concerns/railspress/has_focal_point_spec.rb
+++ b/spec/models/concerns/railspress/has_focal_point_spec.rb
@@ -64,6 +64,13 @@ RSpec.describe Railspress::HasFocalPoint do
       post.header_image_focal_point.update!(overrides: { "card" => { "type" => "crop" } })
       expect(post.image_override(:hero, :header_image)).to be_nil
     end
+
+    it "returns nil when overrides column is NULL" do
+      fp = post.header_image_focal_point
+      fp.save! unless fp.persisted?
+      fp.update_column(:overrides, nil)
+      expect(post.image_override(:hero, :header_image)).to be_nil
+    end
   end
 
   describe "#has_image_override?" do
@@ -297,6 +304,34 @@ RSpec.describe Railspress::FocalPoint do
     it "allows nil override value for context" do
       focal_point.overrides = { "hero" => nil }
       expect(focal_point).to be_valid
+    end
+
+    it "allows nil overrides column" do
+      focal_point.overrides = nil
+      expect(focal_point).to be_valid
+    end
+  end
+
+  describe "#override_for" do
+    let(:saved_focal_point) do
+      Railspress::FocalPoint.create!(record: railspress_posts(:hello_world), attachment_name: "header_image", focal_x: 0.5, focal_y: 0.5, overrides: {})
+    end
+
+    it "returns nil when overrides column is NULL" do
+      saved_focal_point.update_column(:overrides, nil)
+      expect(saved_focal_point.reload.override_for(:hero)).to be_nil
+    end
+
+    it "returns nil for missing context" do
+      saved_focal_point.update!(overrides: { "card" => { "type" => "crop" } })
+      expect(saved_focal_point.override_for(:hero)).to be_nil
+    end
+
+    it "returns override with indifferent access" do
+      saved_focal_point.update!(overrides: { "hero" => { "type" => "crop" } })
+      override = saved_focal_point.override_for(:hero)
+      expect(override[:type]).to eq("crop")
+      expect(override["type"]).to eq("crop")
     end
   end
 end


### PR DESCRIPTION
## Summary

- Guard `FocalPoint#override_for` against nil `overrides` column using `overrides&.dig(context.to_s)`
- The migration sets `default: {}` but records created before that migration (or via raw SQL) can have NULL, causing `NoMethodError: undefined method '[]' for nil`

## Test plan

- [x] Added `#override_for` specs covering nil overrides, missing context, and indifferent access
- [x] Added nil overrides test at the `HasFocalPoint` concern level
- [x] Added validation spec for nil overrides column
- [x] All 50 focal point specs pass