### PR TITLE
Make Lexxy editor toolbar sticky on scroll

### DIFF
--- a/app/assets/stylesheets/railspress/admin/components/lexxy.css
+++ b/app/assets/stylesheets/railspress/admin/components/lexxy.css
@@ -4,8 +4,13 @@
  */
 
 :where(lexxy-toolbar){
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--rp-bg-elevated, #fff);
   margin-bottom: 20px;
   padding-bottom: 10px;
+  border-bottom: 1px solid var(--rp-border);
 }
 
 /* Fix toolbar dropdown alignment (color/link buttons) */


### PR DESCRIPTION
## Summary
- Toolbar stays visible at the top when scrolling through long blog posts
- Added `position: sticky; top: 0` to `<lexxy-toolbar>` element
- Includes visual separation with subtle border-bottom

## Why
When editing long posts, users lose access to formatting tools (bold, image insert, links) after scrolling down. This prevents them from easily inserting images or formatting mid-document without scrolling back up.

## Changes
- Added `position: sticky; top: 0; z-index: 10` to `:where(lexxy-toolbar)` CSS rule
- Set `background: var(--rp-bg-elevated, #fff)` to prevent content bleed-through
- Added `border-bottom: 1px solid var(--rp-border)` for visual separation

## Testing
- [x] Edit a post with long content — toolbar should remain visible at viewport top
- [x] Verify toolbar buttons and dropdowns still work while sticky
- [x] Test markdown mode toggle still functions