### PR TITLE
Provide more settings in install

### DIFF
--- a/lib/generators/railspress/install/templates/initializer.rb
+++ b/lib/generators/railspress/install/templates/initializer.rb
@@ -7,8 +7,14 @@ Railspress.configure do |config|
   # Uncomment to enable:
   # config.enable_authors
   # config.author_class_name = "User"
+  # config.author_scope = :admins
   # config.current_author_method = :current_user
   # config.current_author_proc = -> { Current.user }
+
+  # Header images for Posts
+  # Uncomment to enable:
+  # config.enable_post_images
+  # config.enable_focal_points
 
   # === CMS Content Elements (opt-in) ===
   # Adds content groups, content elements, and the cms_element/cms_value


### PR DESCRIPTION
## Summary

Put more settings into the install template to make config easier for new users. Tiny change, but as someone seeing this with fresh eyes it saves some digging in the docs.

## Changes

listed author_scope, enable_post_images, and enable_focal_points